### PR TITLE
Fix brotli compression support for .splat file loading

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to gsplat.js
+
+## Development Setup
+
+1. Clone the repository
+2. Install dependencies: `npm install`
+3. Build WASM: `npm run build:wasm`
+4. Build library: `npm run build`
+
+## Testing
+
+- Run tests: `npm test`
+- Lint code: `npm run lint`
+- Format code: `npm run format`
+
+## Making Changes
+
+1. Create a feature branch from `main`
+2. Make your changes
+3. Ensure tests pass and code is linted
+4. Update version in `package.json` if needed
+5. Create a pull request
+
+## File Structure
+
+- `src/` - TypeScript source code
+- `examples/` - Example applications
+- `playground/` - Development testing (gitignored)
+- `dist/` - Built library output
+
+## Release Process
+
+Releases are handled through GitHub Actions workflows. The build process includes WebAssembly compilation using Emscripten.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gsplat",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "description": "JavaScript Gaussian Splatting library",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/utils/LoaderUtils.ts
+++ b/src/utils/LoaderUtils.ts
@@ -66,7 +66,12 @@ export async function loadRequestDataIntoBuffer(
     res: Response,
     onProgress?: (progress: number) => void,
 ): Promise<Uint8Array> {
-    if (res.headers.has("content-length")) {
+    const contentEncoding = res.headers.get("content-encoding");
+    const isCompressed =
+        contentEncoding &&
+        (contentEncoding.includes("br") || contentEncoding.includes("gzip") || contentEncoding.includes("deflate"));
+
+    if (res.headers.has("content-length") && !isCompressed) {
         return loadDataIntoBuffer(res, onProgress);
     } else {
         return loadChunkedDataIntoBuffer(res, onProgress);


### PR DESCRIPTION
- Detect Content-Encoding headers (br, gzip, deflate) in LoaderUtils
- Use chunked loading when compression is detected to avoid content-length mismatch
- Bump version to 1.2.5
- Add CONTRIBUTING.md for development guidelines