### PR TITLE
Fix splat sizing when changing FOV at runtime

### DIFF
--- a/src/renderers/webgl/programs/RenderProgram.ts
+++ b/src/renderers/webgl/programs/RenderProgram.ts
@@ -479,6 +479,7 @@ class RenderProgram extends ShaderProgram {
 
             gl.uniformMatrix4fv(u_projection, false, this._camera.data.projectionMatrix.buffer);
             gl.uniformMatrix4fv(u_view, false, this._camera.data.viewMatrix.buffer);
+            gl.uniform2fv(u_focal, new Float32Array([this._camera.data.fx, this._camera.data.fy]));
 
             gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
             gl.vertexAttribPointer(positionAttribute, 2, gl.FLOAT, false, 0, 0);

--- a/src/renderers/webgl/programs/VideoRenderProgram.ts
+++ b/src/renderers/webgl/programs/VideoRenderProgram.ts
@@ -323,6 +323,7 @@ class VideoRenderProgram extends ShaderProgram {
 
             gl.uniformMatrix4fv(u_projection, false, this._camera.data.projectionMatrix.buffer);
             gl.uniformMatrix4fv(u_view, false, this._camera.data.viewMatrix.buffer);
+            gl.uniform2fv(u_focal, new Float32Array([this._camera.data.fx, this._camera.data.fy]));
             gl.uniform1f(u_time, Math.sin(Date.now() / 1000) / 2 + 1 / 2);
 
             gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);


### PR DESCRIPTION
The focal uniform in the vertex shader was only set once during initialization, but the projection matrix was updated every frame. When camera.data.fx/fy changed at runtime, splat positions moved correctly but their sizes didn't scale — causing visible gaps between splats.

Updated both RenderProgram and VideoRenderProgram to upload the focal uniform every frame alongside projection and view.